### PR TITLE
07章の修正

### DIFF
--- a/books/writing-wasm-runtime-in-rust/07_decode_function_2.md
+++ b/books/writing-wasm-runtime-in-rust/07_decode_function_2.md
@@ -70,7 +70,7 @@ title: "関数のデコード実装 ~ 命令のデコードまで ~"
  
 -fn decode_type_section(_input: &[u8]) -> IResult<&[u8], Vec<FuncType>> {
 -    let func_types = vec![FuncType::default()];
-+fn decode_vaue_type(input: &[u8]) -> IResult<&[u8], ValueType> {
++fn decode_value_type(input: &[u8]) -> IResult<&[u8], ValueType> {
 +    let (input, value_type) = le_u8(input)?;
 +    Ok((input, value_type.into()))
 +}
@@ -86,12 +86,12 @@ title: "関数のデコード実装 ~ 命令のデコードまで ~"
 +
 +        let (rest, size) = leb128_u32(rest)?; // 3
 +        let (rest, types) = take(size)(rest)?;
-+        let (_, types) = many0(decode_vaue_type)(types)?; // 4
++        let (_, types) = many0(decode_value_type)(types)?; // 4
 +        func.params = types;
 +
 +        let (rest, size) = leb128_u32(rest)?; // 5
 +        let (rest, types) = take(size)(rest)?;
-+        let (_, types) = many0(decode_vaue_type)(types)?; // 6
++        let (_, types) = many0(decode_value_type)(types)?; // 6
 +        func.results = types;
  
 -    // TODO: 引数と戻り値のデコード
@@ -104,7 +104,7 @@ title: "関数のデコード実装 ~ 命令のデコードまで ~"
 ```
 
 `many0()`は受け取った関数を使って、入力が終わるまでパースし続けて、入力の残りとパース結果を`Vec`で返す関数である。
-これを使って、「`u8`を読み取って`ValueType`に変換」する関数である`decode_vaue_type()`を繰り返している。
+これを使って、「`u8`を読み取って`ValueType`に変換」する関数である`decode_value_type()`を繰り返している。
 このように、`many0()`を使うことで`for`を使ってデコードする必要がなくなり、実装がシンプルになる。
 
 実装はできたので、続けてテストを実装していくが、現時点では引数のテストのみとする。

--- a/books/writing-wasm-runtime-in-rust/07_decode_function_2.md
+++ b/books/writing-wasm-runtime-in-rust/07_decode_function_2.md
@@ -424,7 +424,7 @@ pub enum Opcode {
 
 続けて、命令の定義を追加する。
 
-```diff:src/binary/module.rs
+```diff:src/binary/instruction.rs
  #[derive(Debug, Clone, PartialEq, Eq)]
  pub enum Instruction {
      End,


### PR DESCRIPTION
[RustでWasm Runtimeを実装する](https://zenn.dev/skanehira/books/writing-wasm-runtime-in-rust)の7章の修正提案です。

* `decode_vaue_type`を`decode_value_type`に修正
* Instructionを記載するファイルを`src/binary/module.rs`から`src/binary/instruction.rs`に修正