### PR TITLE
誤植？修正。「 RustでWasm Runtimeを実装する　第12章」

### DIFF
--- a/books/writing-wasm-runtime-in-rust/12_build_runtime_additional_instruction.md
+++ b/books/writing-wasm-runtime-in-rust/12_build_runtime_additional_instruction.md
@@ -62,7 +62,7 @@ index 40f20fd..8426948 100644
          Opcode::Call => {
 ```
 
-```diff:src/binary/module.rs
+```diff:src/binary/runtime.rs
 diff --git a/src/execution/runtime.rs b/src/execution/runtime.rs
 index 3c492bc..c52de7b 100644
 --- a/src/execution/runtime.rs


### PR DESCRIPTION
fix: runtime.rsであるべきコードブロックがmodule.rsの表記になっている点を修正。

local.set実装のセクションの4個目のコードブロック部です。