### PR TITLE
fix: corrected from src/execution/lib.rs to src/lib.rs

### DIFF
--- a/books/writing-wasm-runtime-in-rust/09_build_runtime_func_execute.md
+++ b/books/writing-wasm-runtime-in-rust/09_build_runtime_func_execute.md
@@ -70,7 +70,7 @@ impl std::ops::Add for Value {
 pub mod value;
 ```
 
-```diff:src/execution/lib.rs
+```diff:src/lib.rs
 diff --git a/src/lib.rs b/src/lib.rs
 index 96eab66..ec63376 100644
 --- a/src/lib.rs


### PR DESCRIPTION
Hello, I found a mistake about the path of the sample code snippets in the writing-wasm-runtime-in-rust book and then fixed it. Thanks for a fantastic book!