### PR TITLE
03_intro_wasm.md: `--invoke add` の位置を変更

### DIFF
--- a/books/writing-wasm-runtime-in-rust/03_intro_wasm.md
+++ b/books/writing-wasm-runtime-in-rust/03_intro_wasm.md
@@ -71,7 +71,7 @@ $ ls
  add.wasm
  add.wat
 # wasmtime を使って関数を実行する
-$ wasmtime add.wasm --invoke add 1 2
+$ wasmtime --invoke add add.wasm 1 2
 warning: using `--invoke` with a function that takes arguments is experimental and may break in the future
 warning: using `--invoke` with a function that returns values is experimental and may break in the future
 3


### PR DESCRIPTION
素晴らしい記事をありがとうございます mm

wasmtime の仕様が変わったのか、 `--invoke add` を wasmtime コマンドの直後に配置しないと動作しなかったので変更をPRさせていただきます。

```
$ wasmtime --invoke add add.wasm 1 2 
warning: using `--invoke` with a function that takes arguments is experimental and may break in the future
warning: using `--invoke` with a function that returns values is experimental and may break in the future
3
```

確認したwasmtimeのバージョンです:

```
$ wasmtime --version
wasmtime 25.0.1 (b4cb894c9 2024-09-24)
```