### PR TITLE
15_extra_execute_fibonacci: "then" is required

### DIFF
--- a/books/writing-wasm-runtime-in-rust/15_extra_execute_fibonacci.md
+++ b/books/writing-wasm-runtime-in-rust/15_extra_execute_fibonacci.md
@@ -10,7 +10,7 @@ title: "番外編 ~ フィボナッチ関数が動くまで ~"
   (func $fib (export "fib") (param $n i32) (result i32)
     (if
       (i32.lt_s (local.get $n) (i32.const 2))
-      (return (i32.const 1))
+      (then (return (i32.const 1)))
     )
     (return
       (i32.add


### PR DESCRIPTION
ワークショップを進めていて、そのままではwat2wasmでコンパイルできないコードを見つけたので修正しました！

### 出ていたエラー

```console
fib.wat:6:5: error: unexpected token ), expected (.
    )
    ^
```

### コンパイル結果

```console
$ wasm-objdump -d examples/fib.wasm 

fib.wasm:       file format wasm 0x1

Code Disassembly:

000021 func[0] <fib>:
 000022: 20 00                      | local.get 0
 000024: 41 02                      | i32.const 2
 000026: 48                         | i32.lt_s
 000027: 04 40                      | if
 000029: 41 01                      |   i32.const 1
 00002b: 0f                         |   return
 00002c: 0b                         | end
 00002d: 20 00                      | local.get 0
 00002f: 41 02                      | i32.const 2
 000031: 6b                         | i32.sub
 000032: 10 00                      | call 0 <fib>
 000034: 20 00                      | local.get 0
 000036: 41 01                      | i32.const 1
 000038: 6b                         | i32.sub
 000039: 10 00                      | call 0 <fib>
 00003b: 6a                         | i32.add
 00003c: 0f                         | return
 00003d: 0b                         | end
```